### PR TITLE
Fixed Download Request Memory leak once the download gets started. Th…

### DIFF
--- a/LxFTPRequest/LxFTPRequest.m
+++ b/LxFTPRequest/LxFTPRequest.m
@@ -545,6 +545,9 @@ void downloadReadStreamClientCallBack(CFReadStreamRef stream, CFStreamEventType 
     CFWriteStreamClose(self.writeStream);
     CFRelease(self.writeStream);
     self.writeStream = nil;
+    
+    CFBridgingRelease(_streamClientContext.info);
+    _streamClientContext.info = NULL;
 }
 
 @end


### PR DESCRIPTION
Fixed Download Request Memory leak once the download gets started. The request object never gets released once it gets started. By applying this 2 lines, it resolves the problem of download request. The object will get released once the download gets finished or stopped.